### PR TITLE
Restart fixes

### DIFF
--- a/src/completionProviders.js
+++ b/src/completionProviders.js
@@ -1,4 +1,5 @@
 const vscode = require('vscode');
+const utilities = require('./utilities');
 
 
 /**
@@ -152,11 +153,9 @@ function makeCompletionItem(key, position) {
   let item = new vscode.CompletionItem(key, vscode.CompletionItemKind.Text);
   item.range = new vscode.Range(position, position);
 
-  const regex = /^(.+)\s\((.*)\)$|^(.*)$/m;
-      // eslint-disable-next-line no-unused-vars
-  let [fullString, configName, folderName] = key.match(regex);
+  let setting = utilities.parseConfigurationName(key);
 
-  item.sortText = folderName;
+  item.sortText = setting.folder;
 
   // remove spaces added to align folders in completionProvider
   let stripSpaces = /(\s{2,})(\([^)]+\))$/g;

--- a/src/handleDebugSession.js
+++ b/src/handleDebugSession.js
@@ -21,6 +21,8 @@ exports.stopStart = async function (session, name) {
 
   await vscode.debug.stopDebugging(session);
 
+  // Give it a moment to stop fully.
+  await new Promise(resolve => setTimeout(resolve, 1000));
 
   let setting = utilities.parseConfigurationName(name);
 

--- a/src/handleDebugSession.js
+++ b/src/handleDebugSession.js
@@ -21,20 +21,17 @@ exports.stopStart = async function (session, name) {
 
   await vscode.debug.stopDebugging(session);
 
-  const regex = /^(.+?)\s+\(([^)]*)\)$|^(.*)$/m;
-  // eslint-disable-next-line no-unused-vars
-  let [fullString, configName, folderName, configNameNoFolder] = name.match(regex);
 
-  let ConfigWorkSpaceFolder;
+  let setting = utilities.parseConfigurationName(name);
 
-  if (folderName === 'code-wordspace') vscode.debug.startDebugging(undefined, configName);
+  if (setting.folder === 'code-workspace') vscode.debug.startDebugging(undefined, setting.config);
   else {
     // check if folderName is empty, if so use the  workSpaceFolder of the active editor
-    if (!folderName) ConfigWorkSpaceFolder = utilities.getActiveWorkspaceFolder();
-    else ConfigWorkSpaceFolder = vscode.workspace.workspaceFolders.find(ws => ws.name === folderName);
+    let workspace = setting.folder
+      ? vscode.workspace.workspaceFolders.find(ws => ws.name === setting.folder)
+      : utilities.getActiveWorkspaceFolder();
 
-    configName = configName ? configName : configNameNoFolder;
-    await vscode.debug.startDebugging(ConfigWorkSpaceFolder, configName);
+    await vscode.debug.startDebugging(workspace, setting.config);
     vscode.commands.executeCommand('workbench.debug.action.focusCallStackView');
   }
 }
@@ -71,11 +68,11 @@ exports.isMatchingDebugSession = function (debugSessions, name) {
 
   if (!debugSessions.size) return { match:match, session:matchSession};
 
-  let folderName = name.replace(/.*\(([\w\s]*)\)/, '$1');
-  let launchName = name.replace(/^(.*?)\s*\(.*\)$/m, '$1');
+  let setting = utilities.parseConfigurationName(name);
 
   debugSessions.forEach(session => {
-    if (session.name.replace(/(.*):.*$/m, '$1') === launchName && session.workspaceFolder.name === folderName) {
+    if (session.name.replace(/(.*):.*$/m, '$1') === setting.config
+      && !setting.folder || setting.folder === session.workspaceFolder.name ) {
       match = true;
       matchSession = session;
     }

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -9,3 +9,15 @@ exports.getActiveWorkspaceFolder  = function()  {
   if (!folders)  vscode.window.showErrorMessage('There is no workspacefolder open.')
   return vscode.workspace.getWorkspaceFolder(vscode.window.activeTextEditor.document.uri);
 };
+
+exports.parseConfigurationName = function(name) {
+  const regex = /^(.+?)\s+\(([^)]*)\)$|^(.*)$/m;
+
+  // eslint-disable-next-line no-unused-vars
+  let [fullString, configName, folderName, configNameNoFolder] = name.match(regex);
+  return {
+    fullName: fullString,
+    folder: folderName,
+    config: configName ?? configNameNoFolder
+  }
+}


### PR DESCRIPTION
This PR fixed two issues with the current restart behavior.
- One is that while launching currently works without providing a folder (useful if you don't want to hardcode a folder name for other developers), it does not correctly identify the session to restart. This is fixed by refactoring the configuration matching and applying it everywhere.
- The second is the fact that using the stop/start option can easily fail because VSCode does not actually wait for the process to stop before resolving the promise (don't ask me why). I added a 1 second timer, which was enough in all test cases on my old laptop.